### PR TITLE
サブドメイン時の画像URL置換をカスタムフィールドから出力している画像にも適用

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![eye-catch.jpg](docs/images/eye-catch.jpg)
 
-WordPressと[さくらのクラウド ウェブアクセラレータ](http://cloud.sakura.ad.jp/specification/option/#option-content05)との連携を行うためのプラグインです。
+WordPressと[さくらのクラウド ウェブアクセラレータ](https://cloud.sakura.ad.jp/specification/web-accelerator/)との連携を行うためのプラグインです。
 
 ウェブアクセラレータを利用すると、オリジンサーバーへの負荷を最小限にしつつ、
 アクセス急増時でも安定してサイトを表示することができます。

--- a/docs/About.md
+++ b/docs/About.md
@@ -4,7 +4,7 @@
 
 ![eye-catch.jpg](images/eye-catch.jpg)
 
-`wp-sacloud-webaccel`は、WordPressと[さくらのクラウド ウェブアクセラレータ](http://cloud.sakura.ad.jp/specification/option/#option-content05)を連携させるためのプラグインです。
+`wp-sacloud-webaccel`は、WordPressと[さくらのクラウド ウェブアクセラレータ](https://cloud.sakura.ad.jp/specification/web-accelerator/)を連携させるためのプラグインです。
 
 以下のような機能を持っています。
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -73,8 +73,9 @@ APIキーを作成したら、以下の値を控えておいてください。
 
 以下のマニュアルを参考に設定を行ってください。
 
-  - 独自ドメイン型の場合：[利用手順(独自ドメイン)](http://cloud-news.sakura.ad.jp/webaccel/manual01/)
-  - サブドメイン型の場合：[利用手順(サブドメイン)](http://cloud-news.sakura.ad.jp/webaccel/manual02/)
+  - 独自ドメイン型の場合：[ 初期設定（独自ドメイン利用）](https://manual.sakura.ad.jp/cloud/webaccel/manual/settings-domain.html)
+  - 独自ドメインのサブドメイン型の場合：[初期設定（独自ドメインにサブドメインを新規設定して利用）](https://manual.sakura.ad.jp/cloud/webaccel/manual/settings-domain-add-subdomain.html)
+  - *.webaccel.jp のサブドメイン型の場合：[初期設定（サブドメイン利用） ](https://manual.sakura.ad.jp/cloud/webaccel/manual/settings-subdomain.html)
 
 #### サブドメイン名の確認(サブドメイン型の場合のみ必要)
 

--- a/readme.txt
+++ b/readme.txt
@@ -12,13 +12,13 @@ WordPressとさくらのクラウド ウェブアクセラレータを連携さ�
 
 == Description ==
 
-[さくらのクラウド ウェブアクセラレータ](http://cloud.sakura.ad.jp/specification/option/#option-content05)との連携を行います。
+[さくらのクラウド ウェブアクセラレータ](https://cloud.sakura.ad.jp/specification/web-accelerator/)との連携を行います。
 
 ウェブアクセラレータを利用することにより、オリジンサーバーへの負荷を最小限にしつつ、アクセス急増時でも安定してサイトを表示することができます。
 
 このプラグインを利用することで、ウェブアクセラレータとの連携に必要なレスポンスヘッダの出力や、データ更新時のキャッシュクリアなどが自動化されます。
 
-[サブドメイン方式](http://cloud-news.sakura.ad.jp/webaccel/manual02/)での連携にも対応しており、
+[サブドメイン方式](https://manual.sakura.ad.jp/cloud/webaccel/manual/settings-subdomain.html)での連携にも対応しており、
 メディアファイルのURLのみをウェブアクセラレータのサブドメインURLに書き換えることができます。
 
 = Features =

--- a/wp-sacloud-webaccel.php
+++ b/wp-sacloud-webaccel.php
@@ -34,7 +34,7 @@ function sacloud_webaccel_start()
 
         // for media(attachment)
         if (sacloud_webaccel_get_option("use-subdomain") == 1) {
-            //add_filter('wp_get_attachment_url', 'sacloud_webaccel_subdomain_url');
+            add_filter('wp_get_attachment_url', 'sacloud_webaccel_subdomain_url');
             add_filter('wp_calculate_image_srcset', 'sacloud_webaccel_calculate_image_srcset', 10, 5);
             add_filter('the_content', 'sacloud_webaccel_filter_the_content', 888888);
         }


### PR DESCRIPTION
Twitterではお世話になりました。
こちらの環境でプラグインを有効にしても画像URLが置換されなかったのは、ほとんどの画像をthe_contentからではなく、アイキャッチやカスタムフィールドから出力しているためであることに気づきました。
そこで、コメントアウトしてあった wp_get_attachment_url のフィルターフックを有効にしたところ、希望通りの動作になりました。

こちらのフックもそのまま活かしたほうが良いのではと思い、プルリクエストにしました。（何か既知の問題があって止めていたようでしたらすみません、その場合はスルーしていただいて結構です）

また、ついでですが、マニュアル内のリンクが古くなっていてリンク切れをしていた部分を修正しました。