### PR TITLE
Rewrite image url from custom fields, post thumbnails

### DIFF
--- a/wp-sacloud-webaccel.php
+++ b/wp-sacloud-webaccel.php
@@ -34,7 +34,7 @@ function sacloud_webaccel_start()
 
         // for media(attachment)
         if (sacloud_webaccel_get_option("use-subdomain") == 1) {
-            //add_filter('wp_get_attachment_url', 'sacloud_webaccel_subdomain_url');
+            add_filter('wp_get_attachment_url', 'sacloud_webaccel_subdomain_url');
             add_filter('wp_calculate_image_srcset', 'sacloud_webaccel_calculate_image_srcset', 10, 5);
             add_filter('the_content', 'sacloud_webaccel_filter_the_content', 888888);
         }

--- a/wp-sacloud-webaccel.php
+++ b/wp-sacloud-webaccel.php
@@ -1149,7 +1149,6 @@ function sacloud_webaccel_send_cache_header()
     // 2) ページング2ページ目以降はキャッシュしない
     // 3) 検索結果ページはキャッシュしない
     // ただし画像(直リンク)は.htaccessで処理しているため全てキャッシュ対象となる
-    // 4) カスタムフィールド sacloud_nocache に 1 が入っているページはキャッシュしない
     if (!is_user_logged_in() && !is_paged() && !is_search()) {
         if (!$send_header && sacloud_webaccel_get_option("enable-page") == "1") {
             $send_header = is_front_page() || is_home();
@@ -1162,11 +1161,6 @@ function sacloud_webaccel_send_cache_header()
             // for comment feed (http(s)://host/wp/comments
             if (!$send_header && is_feed()) {
                 $send_header = true;
-            }
-
-            if ( get_post_meta( get_the_ID(), 'sacloud_nocache', true ) == "1" ) {
-                $send_header = false;
-                nocache_headers();
             }
         }
         if (!$send_header && sacloud_webaccel_get_option("enable-media") == "1") {

--- a/wp-sacloud-webaccel.php
+++ b/wp-sacloud-webaccel.php
@@ -1149,6 +1149,7 @@ function sacloud_webaccel_send_cache_header()
     // 2) ページング2ページ目以降はキャッシュしない
     // 3) 検索結果ページはキャッシュしない
     // ただし画像(直リンク)は.htaccessで処理しているため全てキャッシュ対象となる
+    // 4) カスタムフィールド sacloud_nocache に 1 が入っているページはキャッシュしない
     if (!is_user_logged_in() && !is_paged() && !is_search()) {
         if (!$send_header && sacloud_webaccel_get_option("enable-page") == "1") {
             $send_header = is_front_page() || is_home();
@@ -1161,6 +1162,11 @@ function sacloud_webaccel_send_cache_header()
             // for comment feed (http(s)://host/wp/comments
             if (!$send_header && is_feed()) {
                 $send_header = true;
+            }
+
+            if ( get_post_meta( get_the_ID(), 'sacloud_nocache', true ) == "1" ) {
+                $send_header = false;
+                nocache_headers();
             }
         }
         if (!$send_header && sacloud_webaccel_get_option("enable-media") == "1") {


### PR DESCRIPTION
サブドメイン時の画像URL置換をアイキャッチやカスタムフィールドから出力している画像にも適用できるよう、wp_get_attachment_url のフィルターフックを有効にしました。