### PR TITLE
fix: Disable rewriting image URL  in dashboard

### DIFF
--- a/wp-sacloud-webaccel.php
+++ b/wp-sacloud-webaccel.php
@@ -1197,7 +1197,7 @@ function sacloud_webaccel_subdomain_url($wpurl)
 {
 
     $isSubdomain = sacloud_webaccel_get_option('use-subdomain') == '1';
-    if (!$isSubdomain) {
+    if ( !$isSubdomain || is_admin() ) {
         return $wpurl;
     }
 


### PR DESCRIPTION
先日マージしていただいた #29 のプルリクに不備がありましたので修正です。
wp_get_attachment_url のフックを有効にしたことで、サブドメイン利用時、管理画面から挿入する画像のURLが、アクセラレータのURLに書き換えられてしまうようになってしまいました。

この状態で記事を公開するとDB内にアクセラレータのURLが入ってしまい、利用をやめた際に問題が出てしまうため、管理画面上ではURLの書き換えを行わないよう条件分岐を追加しました。
<img width="622" alt="fix-admin-src" src="https://user-images.githubusercontent.com/3164205/44415449-69557900-a5ab-11e8-8b19-dd176727da5c.png">


