### PR TITLE
Invalid argument supplied for foreachエラー対応

### DIFF
--- a/wp-sacloud-webaccel.php
+++ b/wp-sacloud-webaccel.php
@@ -1230,13 +1230,15 @@ function sacloud_webaccel_calculate_image_srcset($sources, $size_array, $image_s
     $protocol = sacloud_webaccel_get_option('subdomain-ssl') == '1' ? "https://" : "http://";
     $subdomain = sacloud_webaccel_get_option('subdomain-name') . ".user.webaccel.jp";
 
-    foreach ($sources as &$src) {
-        $url = $src['url'];
+    if (is_array($sources)) {
+        foreach ($sources as &$src) {
+            $url = $src['url'];
 
-        $path = str_replace($homeURL, '', $url);
-        $src['url'] = $protocol . $subdomain . $path;
+            $path = str_replace($homeURL, '', $url);
+            $src['url'] = $protocol . $subdomain . $path;
+        }
+        return $sources;
     }
-    return $sources;
 }
 
 /**


### PR DESCRIPTION
# 概要

本日、本プラグインを導入してみたところ、下記エラーが大量に吐かれていることを確認いたしました。
そちらの修正対応です。

```sh
[18-Sep-2021 13:15:58 UTC] PHP Warning:  Invalid argument supplied for foreach() in /var/www/html/photoshopvip.net/wp-content/plugins/wp-sacloud-webaccel/wp-sacloud-webaccel.php on line 1233
```

本修正が適切ではないと判断いただいた場合は、クローズいただいて問題ございません。

## 利用環境

- PHP7.0
- CentOS Linux release 7.8.2003 (Core)

